### PR TITLE
Clarify "Root File" setting description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 * ([#85](https://github.com/harrisont/fastbuild-vscode/issues/85)) Fix the `not` in `not in` missing syntax highlighting. The `in` was colored properly but the `not` was not. Thanks to [@xoorath](https://github.com/xoorath) for pointing out this bug.
+* Explain in the "Root File" setting description that you need to either modify or re-open the files for this setting to be picked up.
 
 # v0.16.0
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 					"scope": "window",
 					"type": "string",
 					"default": "",
-					"markdownDescription": "Optional absolute path to the root `fbuild.bff` file. Set when running FASTBuild with the `-config <path>` command line option. The root is automatically found when it is in a parent directory, so it is not necessary to specify in that case."
+					"markdownDescription": "Optional absolute path to the root `fbuild.bff` file. Set when running FASTBuild with the `-config <path>` command line option. The root is automatically found when it is in a parent directory, so it is not necessary to specify in that case. Note that you need to either modify or re-open the files for this setting to be picked up."
 				},
 				"fastbuild.trace.server": {
 					"order": 2,


### PR DESCRIPTION
Explain in the "Root File" setting description that you need to either modify or re-open the files for this setting to be picked up.